### PR TITLE
fix: double sided cards handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ imageCache/
 *.json
 *.pyc
 __pycache__/
+.idea

--- a/deckconverter/images.py
+++ b/deckconverter/images.py
@@ -3,6 +3,7 @@ import requests
 import shutil
 import subprocess
 from . import queue
+import hashlib
 
 montagePath = None
 
@@ -46,13 +47,10 @@ def generateFilenameFromUrl(url):
     """
     Transforms a card URL into a local filename in the format
 
-    imageCache/setname_cardnumber.jpg.
+    Example:
+    imageCache/8bc3ef6a247ea3e4d55489529cdcd84c.jpg.
     """
-    reverse = url[::-1]
-    filename = reverse[:reverse.find('/')][::-1]
-    reverse = reverse[reverse.find('/')+1:]
-    setname = reverse[:reverse.find('/')][::-1]
-    return 'imageCache/'+ setname + '_' + filename
+    return 'imageCache/'+ hashlib.md5(url.encode()).hexdigest() + '.jpg'
 
 def downloadCardImageByUrl(url):
     """

--- a/deckconverter/processor.py
+++ b/deckconverter/processor.py
@@ -131,9 +131,10 @@ def generateProcessedCardEntryFromCardInfo(cardInfo, cardName=None):
     if cardInfo['layout'] == 'transform':
         frontFaceUrl = ""
         backFaceUrl = ""
-        for cardFace in cardInfo['card_faces']:
+        for cardFaceIndex in range(len(cardInfo['card_faces'])):
+            cardFace = cardInfo['card_faces'][cardFaceIndex]
             imageUrl = cardFace['image_uris']['large']
-            if (cardFace['name'] == cardName):
+            if (cardFaceIndex == 0):
                 frontFaceUrl = stripUselessNumbers(imageUrl)
             else:
                 backFaceUrl = stripUselessNumbers(imageUrl)


### PR DESCRIPTION
Hi. A small PR to fix double-sided card import from scryfall.

What I did:
1) Use hashes for cached images names. Scryfall changed format, so previous handling created same filename for both sides of card. Overall I think hashes are more robust solution.
2) Instead of comparing `cardFace['name'] == cardName` I just used index. Again, they probably changed API.

Here's the small test deck if you want to test this on your side (I personally genned Innistrad, and had no issues).

```
https://scryfall.com/card/isd/46
https://scryfall.com/card/isd/47
```

Thanks.